### PR TITLE
Modify `x.shape[0]` to `x_rope.shape[0]` at line 188

### DIFF
--- a/labml_nn/transformers/rope/__init__.py
+++ b/labml_nn/transformers/rope/__init__.py
@@ -185,7 +185,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         # \end{align}
         #
         # for $i \in {1, 2, ..., \frac{d}{2}}$
-        x_rope = (x_rope * self.cos_cached[:x.shape[0]]) + (neg_half_x * self.sin_cached[:x.shape[0]])
+        x_rope = (x_rope * self.cos_cached[:x_rope.shape[0]]) + (neg_half_x * self.sin_cached[:x_rope.shape[0]])
 
         #
         return torch.cat((x_rope, x_pass), dim=-1)


### PR DESCRIPTION
Since we just add RoPE to `x_rope`, so more precisely, we should use the `cos_cached[:x_rope.shape[0]]` and `sin_cached[:x_rope.shape[0]]` instead.